### PR TITLE
Add flexdll 0.43 and ocaml 5.1.0~alpha2

### DIFF
--- a/packages/flexdll/flexdll.0.43/opam
+++ b/packages/flexdll/flexdll.0.43/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+authors: "Alain Frisch"
+maintainer: "David Allsopp <david@tarides.com>"
+bug-reports: "https://github.com/ocaml/flexdll/issues"
+dev-repo: "git+https://github.com/ocaml/flexdll.git"
+homepage: "https://github.com/ocaml/flexdll#readme"
+license: "Zlib"
+synopsis: "FlexDLL Sources"
+description: "Source package for FlexDLL. Installs the required files for
+bootstrapping FlexDLL as part of an OCaml build."
+url {
+  src: "https://github.com/ocaml/flexdll/archive/refs/tags/0.43.tar.gz"
+  checksum: [
+    "md5=6ce706f6c65b2c5adf5791fac678f090"
+    "sha256=10e171ab7d2f8b2f238b53bb9944d4b26686f5703fbc1c059532791bc91be949"
+    "sha512=56048cdbd35fb5e3e34594da00badfe12df98b7d48fb847f96fcae7fd38b3a3458128510b502376250f753ef8f860735e3756875ccb7cceb594f8bb887984a49"
+  ]
+}
+extra-source "flexdll.install" {
+  src: "https://raw.githubusercontent.com/dra27/flexdll/6dcb83484e4fdcf5ba708f18befc10d4bb2d4ab9/flexdll.install"
+  checksum: [
+    "md5=2d736c5caeff1663bd3cd1fa803a7d34"
+    "sha256=18953e4630975873e659b481e1bbb2f514897aa41c0e5638c029ea0844ec1884"
+    "sha512=da8435f10010b1513fd945f8b3c21588e7e11a2d8cfa6b20fb3449aeda36b497e3ee3d4d809b9ef6f37073d47a4ab1a0ae6023ddb6790d226eb52b39ae2e9704"
+  ]
+}

--- a/packages/ocaml-variants/ocaml-variants.5.1.0~alpha2+options/files/ocaml-variants.install
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0~alpha2+options/files/ocaml-variants.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-variants/ocaml-variants.5.1.0~alpha2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0~alpha2+options/opam
@@ -14,8 +14,7 @@ depends: [
   "base-domains" {post}
   "base-nnp" {post}
   "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv" }
-  ("flexdll" {os = "win32"} | "flexdll-bin" {os = "win32"} & "flexlink" {os = "win32" & post})
-  "flexdll" {>= "0.43" & os = "cygwin"}
+  ("flexdll" {os = "win32" | os = "cygwin"} | "flexdll-bin" {os = "win32"} & "flexlink" {os = "win32" & post})
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler

--- a/packages/ocaml-variants/ocaml-variants.5.1.0~alpha2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0~alpha2+options/opam
@@ -116,4 +116,3 @@ depopts: [
   #       OCaml should recompile with it.
   "flexdll"
 ]
-available: os = "win32" | os = "cygwin"

--- a/packages/ocaml-variants/ocaml-variants.5.1.0~alpha2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0~alpha2+options/opam
@@ -1,0 +1,120 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "Second alpha release of OCaml 5.1.0"
+maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#5.1"
+depends: [
+  "ocaml" {= "5.1.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "base-domains" {post}
+  "base-nnp" {post}
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv" }
+  ("flexdll" {os = "win32"} | "flexdll-bin" {os = "win32"} & "flexlink" {os = "win32" & post})
+  "flexdll" {>= "0.43" & os = "cygwin"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build-env: [
+  [PATH += "%{lib}%/%{flexdll-bin:installed?flexdll-bin:ocaml}%"]
+  [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+  [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+]
+build: [
+  [
+    # General configuration
+    "./configure" "-C" "--prefix=%{prefix}%" "--docdir=%{doc}%/ocaml"
+
+    # Windows-specific configuration
+    "--with-flexdll=%{flexdll:share}%" {flexdll:installed}
+
+    # Options
+    "--disable-warn-error"
+
+    "--enable-native-compiler" {!ocaml-option-bytecode-only:installed}
+    "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
+
+    "--with-afl" {ocaml-option-afl:installed}
+    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+    "--enable-flambda" {ocaml-option-flambda:installed}
+    "--enable-frame-pointers" {ocaml-option-fp:installed}
+
+    "LIBS=-static" {ocaml-option-static:installed}
+
+    # Force use of cc for macOS and OpenBSD
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "ASPP=cc -c" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+
+    # Windows ports
+    "--build=x86_64-pc-cygwin" {os = "win32" & arch = "x86_64"}
+    "--build=i686-pc-cygwin" {os = "win32" & arch = "i686"}
+
+    "--host=i686-w64-mingw32" {ocaml-option-mingw:installed & ocaml-option-32bit:installed}
+    "--host=x86_64-w64-mingw32" {ocaml-option-mingw:installed & !ocaml-option-32bit:installed}
+    "--host=i686-pc-windows" {ocaml-option-msvc:installed & ocaml-option-32bit:installed}
+    "--host=x86_64-pc-windows" {ocaml-option-msvc:installed & !ocaml-option-32bit:installed}
+
+    # Compilation with musl
+    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "CFLAGS=-Os" {ocaml-option-musl:installed}
+    "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
+
+    # Compilation with sanitisers
+    "LDFLAGS=-Wl,--no-as-needed,-ldl" {ocaml-option-leak-sanitizer:installed | (ocaml-option-address-sanitizer:installed & os!="macos")}
+    "CC=gcc -ldl -fsanitize=leak -fno-omit-frame-pointer -O1 -g" {ocaml-option-leak-sanitizer:installed}
+    "CC=gcc -ldl -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os!="macos"}
+    "CC=clang -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os="macos"}
+
+    # 32-bit compilation (Linux)
+    "--host=i386-pc-linux-gnu" {ocaml-option-32bit:installed & os="linux"}
+    "CC=gcc -m32" {ocaml-option-32bit:installed & os="linux"}
+    "AS=as --32" {ocaml-option-32bit:installed & os="linux"}
+    "ASPP=gcc -m32 -c" {ocaml-option-32bit:installed & os="linux"}
+    "PARTIALLD=ld -r -melf_i386" {ocaml-option-32bit:installed & os="linux"}
+
+    # 32-bit compilation (macOS)
+    "--host=i386-apple-darwin" {ocaml-option-32bit:installed & os="macos"}
+    "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" {ocaml-option-32bit:installed & os="macos"}
+    "AS=as -arch i386" {ocaml-option-32bit:installed & os="macos"}
+    "ASPP=gcc -arch i386 -m32 -c" {ocaml-option-32bit:installed & os="macos"}
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/5.1.0-alpha2.tar.gz"
+}
+extra-files: ["ocaml-variants.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
+  {failure & jobs > 1}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
+]
+conflicts: [ "ocaml-option-fp" "ocaml-option-msvc" ]
+depopts: [
+  "ocaml-option-32bit"
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+  "ocaml-option-musl"
+  "ocaml-option-leak-sanitizer"
+  "ocaml-option-address-sanitizer"
+  "ocaml-option-static"
+  "ocaml-option-mingw"
+  # TODO: the full behaviour for Cygwin _should_ be that if the Cygwin flexdll is installed and opam's flexdll is not requested,
+  #       then use it; if Cygwin's flexdll is _not_ installed then the opam flexdll package should be pulled in (4.13+) or the
+  #       depext system should cause flexdll to be installed (4.12 and earlier). If opam's flexdll is explicitly requested, then
+  #       OCaml should recompile with it.
+  "flexdll"
+]
+available: os = "win32" | os = "cygwin"


### PR DESCRIPTION
This PR assumes that the windows-5.0 branch is a good place to prepare packages until the planned merge into the main opam repo.

Now that flexdll 0.43 was released (congratulations! :smile:), we can have an opam package for OCaml 5.1α2 that compiles on both Windows MinGW and Cygwin.

Notes:
- I wondered whether it would be more convenient to simply move the `flexdll.install` to a `files` subdirectory, rather than fetching from github,
- I didn’t try to generate flexdll-bin packages (knowing that they would most probably be broken... :sweat_smile:) so I required the flexdll package for Cygwin builds,
- I kept the `TODO` comment from the opam file for OCaml 5.0 that says that, on Cygwin, if flexdll is installed via Cygwin, it should be used unless the opam flexdll package is explicitly requested; I’ve been using something along those lines for running tests in CI: [conf-flexdll](https://github.com/shym/custom-opam-repository/blob/master/packages/conf-flexdll/conf-flexdll.0.39/opam) but it is not very robust, as any flexdll in `PATH` is picked up, not necessarily Cygwin’s one,
- if that PR is of interest, I was thinking about adding 5.2.0+trunk too.