### PR TITLE
conf-gmp-powm-sec: fix C compiler selection for Windows

### DIFF
--- a/packages/conf-gmp-powm-sec/conf-gmp-powm-sec.4/opam
+++ b/packages/conf-gmp-powm-sec/conf-gmp-powm-sec.4/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis:
+  "Virtual package relying on a GMP lib with constant-time modular exponentiation"
+description: """\
+This package can only install if the GMP lib is installed on the system and
+corresponds to a version that has the mpz_powm_sec function."""
+maintainer: "Etienne Millon <etienne@cryptosense.com>"
+authors: "Etienne Millon <etienne@cryptosense.com>"
+license: "GPL-1.0-or-later"
+homepage: "http://gmplib.org/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+depends: ["conf-gmp"]
+flags: conf
+build: [
+  ["sh" "-exc" "cc -c $CFLAGS -I/usr/local/include test.c"] {os != "macos" & os != "win32"}
+  [
+		"sh"
+		"-exc"
+		"$(ocamlc -config-var c_compiler) -c $CFLAGS -I/usr/local/include test.c"
+	] {os = "win32" & os-distribution = "cygwinports"}
+  [
+    "sh"
+    "-exc"
+    "cc -c $CFLAGS -I/opt/homebrew/include -I/opt/local/include -I/usr/local/include test.c"
+  ] {os = "macos"}
+]
+extra-files: ["test.c" "md5=29317f477fa828e18428660ef31064fb"]

--- a/packages/conf-gmp-powm-sec/conf-gmp-powm-sec.4/test.c
+++ b/packages/conf-gmp-powm-sec/conf-gmp-powm-sec.4/test.c
@@ -1,0 +1,26 @@
+#include <gmp.h>
+#ifndef __GMP_H__
+#error "No GMP header"
+#endif
+#if __GNU_MP_VERSION < 5
+#error "GMP >= 5 is required to support mpz_powm_sec"
+#endif
+
+void test(void) {
+  mpz_t base;
+  mpz_t exp;
+  mpz_t mod;
+  mpz_t rop;
+
+  mpz_init_set_ui(base, 2u);
+  mpz_init_set_ui(exp, 4u);
+  mpz_init_set_ui(mod, 3u);
+  mpz_init(rop);
+
+  mpz_powm_sec(rop, base, exp, mod);
+
+  mpz_clear(base);
+  mpz_clear(exp);
+  mpz_clear(mod);
+  mpz_clear(rop);
+}


### PR DESCRIPTION
selects C compiler via `ocamlc -config-var c_compiler` for Windows. Copied from `conf-gmp`