### PR TITLE
Remove the `compiler` flag from ocaml-compiler

### DIFF
--- a/packages/ocaml-compiler/ocaml-compiler.5.3.0~alpha1/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.3.0~alpha1/opam
@@ -65,7 +65,7 @@ depends: [
   # Support Packages
   "flexdll" {>= "0.42" & os = "win32"}
 ]
-flags: [ compiler avoid-version ]
+flags: [ avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 x-env-path-rewrite: [
   [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]

--- a/packages/ocaml-compiler/ocaml-compiler.5.3.0~beta1/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.3.0~beta1/opam
@@ -65,7 +65,7 @@ depends: [
   # Support Packages
   "flexdll" {>= "0.42" & os = "win32"}
 ]
-flags: [ compiler avoid-version ]
+flags: [ avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 x-env-path-rewrite: [
   [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]

--- a/packages/ocaml-compiler/ocaml-compiler.5.3.0~beta2/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.3.0~beta2/opam
@@ -65,7 +65,7 @@ depends: [
   # Support Packages
   "flexdll" {>= "0.42" & os = "win32"}
 ]
-flags: [ compiler avoid-version ]
+flags: [ avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 x-env-path-rewrite: [
   [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]

--- a/packages/ocaml-compiler/ocaml-compiler.5.3/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.3/opam
@@ -65,7 +65,7 @@ depends: [
   # Support Packages
   "flexdll" {>= "0.42" & os = "win32"}
 ]
-flags: [ compiler avoid-version ]
+flags: [ avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 x-env-path-rewrite: [
   [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]


### PR DESCRIPTION
Spotted by @kit-ty-kate. At present, if you run `opam init -c 4.14.2` (or `opam switch create 4.14.2`) you get a switch invariant choosing between either ocaml-system.4.14.2 or ocaml-base-compiler.4.14.2

With the new ocaml-compiler package layout, you'd now also get ocaml-compiler.4.14.2 - but this version allows optional reconfiguration options (flambda, etc.) which is a user surprise we should avoid.

The fix is simple and is to remove the `compiler` flag from the package. This makes explicitly using ocaml-compiler in opam 2.0 slightly more awkward, but that hasn't been being suggested anyway.