### PR TITLE
Set `OCAMLTOP_INCLUDE_PATH` (as in `ocaml.5.3.*`)

### DIFF
--- a/packages/ocaml/ocaml.4.08.0/opam
+++ b/packages/ocaml/ocaml.4.08.0/opam
@@ -12,9 +12,15 @@ depends: [
   "ocaml-system" {>= "4.08.0" & < "4.08.1~"}
 ]
 setenv: [
+  [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  # Legacy opam variable
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+  [OCAMLTOP_INCLUDE_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""

--- a/packages/ocaml/ocaml.4.08.1/opam
+++ b/packages/ocaml/ocaml.4.08.1/opam
@@ -12,9 +12,15 @@ depends: [
   "ocaml-system" {>= "4.08.1" & < "4.08.2~"}
 ]
 setenv: [
+  [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  # Legacy opam variable
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+  [OCAMLTOP_INCLUDE_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""

--- a/packages/ocaml/ocaml.4.08.2/opam
+++ b/packages/ocaml/ocaml.4.08.2/opam
@@ -12,9 +12,15 @@ depends: [
   "ocaml-system" {>= "4.08.2" & < "4.08.3~"}
 ]
 setenv: [
+  [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  # Legacy opam variable
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+  [OCAMLTOP_INCLUDE_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""

--- a/packages/ocaml/ocaml.4.09.0/opam
+++ b/packages/ocaml/ocaml.4.09.0/opam
@@ -12,9 +12,15 @@ depends: [
   "ocaml-system" {>= "4.09.0" & < "4.09.1~"}
 ]
 setenv: [
+  [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  # Legacy opam variable
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+  [OCAMLTOP_INCLUDE_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""

--- a/packages/ocaml/ocaml.4.09.1/opam
+++ b/packages/ocaml/ocaml.4.09.1/opam
@@ -12,9 +12,15 @@ depends: [
   "ocaml-system" {>= "4.09.1" & < "4.09.2~"}
 ]
 setenv: [
+  [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  # Legacy opam variable
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+  [OCAMLTOP_INCLUDE_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""

--- a/packages/ocaml/ocaml.4.09.2/opam
+++ b/packages/ocaml/ocaml.4.09.2/opam
@@ -12,9 +12,15 @@ depends: [
   "ocaml-system" {>= "4.09.2" & < "4.09.3~"}
 ]
 setenv: [
+  [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  # Legacy opam variable
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+  [OCAMLTOP_INCLUDE_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""

--- a/packages/ocaml/ocaml.4.10.0/opam
+++ b/packages/ocaml/ocaml.4.10.0/opam
@@ -12,9 +12,15 @@ depends: [
   "ocaml-system" {>= "4.10.0" & < "4.10.1~"}
 ]
 setenv: [
+  [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  # Legacy opam variable
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+  [OCAMLTOP_INCLUDE_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""

--- a/packages/ocaml/ocaml.4.10.1/opam
+++ b/packages/ocaml/ocaml.4.10.1/opam
@@ -12,9 +12,15 @@ depends: [
   "ocaml-system" {>= "4.10.1" & < "4.10.2~"}
 ]
 setenv: [
+  [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  # Legacy opam variable
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+  [OCAMLTOP_INCLUDE_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""

--- a/packages/ocaml/ocaml.4.10.2/opam
+++ b/packages/ocaml/ocaml.4.10.2/opam
@@ -12,9 +12,15 @@ depends: [
   "ocaml-system" {>= "4.10.2" & < "4.10.3~"}
 ]
 setenv: [
+  [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  # Legacy opam variable
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+  [OCAMLTOP_INCLUDE_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""

--- a/packages/ocaml/ocaml.4.10.3/opam
+++ b/packages/ocaml/ocaml.4.10.3/opam
@@ -12,9 +12,15 @@ depends: [
   "ocaml-system" {>= "4.10.3" & < "4.10.4~"}
 ]
 setenv: [
+  [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  # Legacy opam variable
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+  [OCAMLTOP_INCLUDE_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""

--- a/packages/ocaml/ocaml.4.11.0/opam
+++ b/packages/ocaml/ocaml.4.11.0/opam
@@ -12,9 +12,15 @@ depends: [
   "ocaml-system" {>= "4.11.0" & < "4.11.1~"}
 ]
 setenv: [
+  [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  # Legacy opam variable
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+  [OCAMLTOP_INCLUDE_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""

--- a/packages/ocaml/ocaml.4.11.1/opam
+++ b/packages/ocaml/ocaml.4.11.1/opam
@@ -12,9 +12,15 @@ depends: [
   "ocaml-system" {>= "4.11.1" & < "4.11.2~"}
 ]
 setenv: [
+  [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  # Legacy opam variable
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+  [OCAMLTOP_INCLUDE_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""

--- a/packages/ocaml/ocaml.4.11.2/opam
+++ b/packages/ocaml/ocaml.4.11.2/opam
@@ -12,9 +12,15 @@ depends: [
   "ocaml-system" {>= "4.11.2" & < "4.11.3~"}
 ]
 setenv: [
+  [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  # Legacy opam variable
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+  [OCAMLTOP_INCLUDE_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""

--- a/packages/ocaml/ocaml.4.11.3/opam
+++ b/packages/ocaml/ocaml.4.11.3/opam
@@ -12,9 +12,15 @@ depends: [
   "ocaml-system" {>= "4.11.3" & < "4.11.4~"}
 ]
 setenv: [
+  [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  # Legacy opam variable
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+  [OCAMLTOP_INCLUDE_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""

--- a/packages/ocaml/ocaml.4.12.0/opam
+++ b/packages/ocaml/ocaml.4.12.0/opam
@@ -12,9 +12,15 @@ depends: [
   "ocaml-system" {>= "4.12.0" & < "4.12.1~"}
 ]
 setenv: [
+  [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  # Legacy opam variable
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+  [OCAMLTOP_INCLUDE_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""

--- a/packages/ocaml/ocaml.4.12.1/opam
+++ b/packages/ocaml/ocaml.4.12.1/opam
@@ -13,9 +13,15 @@ depends: [
   "dkml-base-compiler" {>= "4.12.1~" & < "4.12.2~"}
 ]
 setenv: [
+  [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  # Legacy opam variable
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+  [OCAMLTOP_INCLUDE_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""

--- a/packages/ocaml/ocaml.4.12.2/opam
+++ b/packages/ocaml/ocaml.4.12.2/opam
@@ -12,9 +12,15 @@ depends: [
   "ocaml-system" {>= "4.12.2" & < "4.12.3~"}
 ]
 setenv: [
+  [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  # Legacy opam variable
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+  [OCAMLTOP_INCLUDE_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""

--- a/packages/ocaml/ocaml.4.13.0/opam
+++ b/packages/ocaml/ocaml.4.13.0/opam
@@ -12,12 +12,15 @@ depends: [
   "ocaml-system" {>= "4.13.0" & < "4.13.1~"}
 ]
 setenv: [
+  [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  # Legacy opam variable
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
 ]
 x-env-path-rewrite: [
   [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+  [OCAMLTOP_INCLUDE_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""

--- a/packages/ocaml/ocaml.4.13.1/opam
+++ b/packages/ocaml/ocaml.4.13.1/opam
@@ -12,12 +12,15 @@ depends: [
   "ocaml-system" {>= "4.13.1" & < "4.13.2~"}
 ]
 setenv: [
+  [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  # Legacy opam variable
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
 ]
 x-env-path-rewrite: [
   [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+  [OCAMLTOP_INCLUDE_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""

--- a/packages/ocaml/ocaml.4.13.2/opam
+++ b/packages/ocaml/ocaml.4.13.2/opam
@@ -12,12 +12,15 @@ depends: [
   "ocaml-system" {>= "4.13.2" & < "4.13.3~"}
 ]
 setenv: [
+  [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  # Legacy opam variable
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
 ]
 x-env-path-rewrite: [
   [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+  [OCAMLTOP_INCLUDE_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""

--- a/packages/ocaml/ocaml.4.14.0/opam
+++ b/packages/ocaml/ocaml.4.14.0/opam
@@ -13,12 +13,15 @@ depends: [
   "dkml-base-compiler" {>= "4.14.0~" & < "4.14.1~"}
 ]
 setenv: [
+  [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  # Legacy opam variable
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
 ]
 x-env-path-rewrite: [
   [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+  [OCAMLTOP_INCLUDE_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""

--- a/packages/ocaml/ocaml.4.14.1/opam
+++ b/packages/ocaml/ocaml.4.14.1/opam
@@ -12,12 +12,15 @@ depends: [
   "ocaml-system" {>= "4.14.1" & < "4.14.2~"}
 ]
 setenv: [
+  [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  # Legacy opam variable
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
 ]
 x-env-path-rewrite: [
   [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+  [OCAMLTOP_INCLUDE_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""

--- a/packages/ocaml/ocaml.4.14.2/opam
+++ b/packages/ocaml/ocaml.4.14.2/opam
@@ -13,12 +13,15 @@ depends: [
   "dkml-base-compiler" {>= "4.14.2~" & < "4.14.3~"}
 ]
 setenv: [
+  [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  # Legacy opam variable
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
 ]
 x-env-path-rewrite: [
   [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+  [OCAMLTOP_INCLUDE_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""

--- a/packages/ocaml/ocaml.4.14.3/opam
+++ b/packages/ocaml/ocaml.4.14.3/opam
@@ -13,12 +13,15 @@ depends: [
   "dkml-base-compiler" {>= "4.14.3~" & < "4.14.4~"}
 ]
 setenv: [
+  [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  # Legacy opam variable
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
 ]
 x-env-path-rewrite: [
   [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+  [OCAMLTOP_INCLUDE_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: CAML_LD_LIBRARY_PATH = ""

--- a/packages/ocaml/ocaml.5.0.0/opam
+++ b/packages/ocaml/ocaml.5.0.0/opam
@@ -12,12 +12,15 @@ depends: [
   "ocaml-system" {>= "5.0.0" & < "5.0.1~"}
 ]
 setenv: [
+  [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  # Legacy opam variable
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
 ]
 x-env-path-rewrite: [
   [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+  [OCAMLTOP_INCLUDE_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: [

--- a/packages/ocaml/ocaml.5.0.1/opam
+++ b/packages/ocaml/ocaml.5.0.1/opam
@@ -13,12 +13,15 @@ depends: [
   "dkml-base-compiler" {>= "5.0.1~" & < "5.0.2~"}
 ]
 setenv: [
+  [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  # Legacy opam variable
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
 ]
 x-env-path-rewrite: [
   [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+  [OCAMLTOP_INCLUDE_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: [

--- a/packages/ocaml/ocaml.5.1.0/opam
+++ b/packages/ocaml/ocaml.5.1.0/opam
@@ -13,12 +13,15 @@ depends: [
   "dkml-base-compiler" {>= "5.1.0~" & < "5.1.1~"}
 ]
 setenv: [
+  [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  # Legacy opam variable
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
 ]
 x-env-path-rewrite: [
   [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+  [OCAMLTOP_INCLUDE_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: [

--- a/packages/ocaml/ocaml.5.1.1/opam
+++ b/packages/ocaml/ocaml.5.1.1/opam
@@ -13,12 +13,15 @@ depends: [
   "dkml-base-compiler" {>= "5.1.1~" & < "5.1.2~"}
 ]
 setenv: [
+  [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  # Legacy opam variable
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
 ]
 x-env-path-rewrite: [
   [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+  [OCAMLTOP_INCLUDE_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: [

--- a/packages/ocaml/ocaml.5.1.2/opam
+++ b/packages/ocaml/ocaml.5.1.2/opam
@@ -13,12 +13,15 @@ depends: [
   "dkml-base-compiler" {>= "5.1.2~" & < "5.1.3~"}
 ]
 setenv: [
+  [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  # Legacy opam variable
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
 ]
 x-env-path-rewrite: [
   [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+  [OCAMLTOP_INCLUDE_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: [

--- a/packages/ocaml/ocaml.5.2.0/opam
+++ b/packages/ocaml/ocaml.5.2.0/opam
@@ -13,12 +13,15 @@ depends: [
   "dkml-base-compiler" {>= "5.2.0~" & < "5.2.1~"}
 ]
 setenv: [
+  [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  # Legacy opam variable
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
 ]
 x-env-path-rewrite: [
   [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+  [OCAMLTOP_INCLUDE_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: [

--- a/packages/ocaml/ocaml.5.2.1/opam
+++ b/packages/ocaml/ocaml.5.2.1/opam
@@ -13,12 +13,15 @@ depends: [
   "dkml-base-compiler" {>= "5.2.1~" & < "5.2.2~"}
 ]
 setenv: [
+  [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  # Legacy opam variable
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
 ]
 x-env-path-rewrite: [
   [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+  [OCAMLTOP_INCLUDE_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: [

--- a/packages/ocaml/ocaml.5.2.2/opam
+++ b/packages/ocaml/ocaml.5.2.2/opam
@@ -13,12 +13,15 @@ depends: [
   "dkml-base-compiler" {>= "5.2.2~" & < "5.2.3~"}
 ]
 setenv: [
+  [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  # Legacy opam variable
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
 ]
 x-env-path-rewrite: [
   [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+  [OCAMLTOP_INCLUDE_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: [

--- a/packages/ocaml/ocaml.5.4.0/opam
+++ b/packages/ocaml/ocaml.5.4.0/opam
@@ -13,12 +13,15 @@ depends: [
   "dkml-base-compiler" {>= "5.4.0~" & < "5.4.1~"}
 ]
 setenv: [
+  [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
   [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  # Legacy opam variable
   [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
 ]
 x-env-path-rewrite: [
   [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+  [OCAMLTOP_INCLUDE_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
 ]
 build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
 build-env: [


### PR DESCRIPTION
Extension of the setting of `OCAMLTOP_INCLUDE_PATH` which was trialled with ocaml/opam-repository#26594.

4.08.0 is the first version of the compiler supporting this environment variable. Updating the remaining packages mitigates the issue seen in https://github.com/dbuenzli/topkg/issues/142 and reported in https://github.com/ocaml/opam-repository/issues/25819#issuecomment-2618893387.

Opened here for review, as the revdeps testing impact is obviously quite large...